### PR TITLE
Fix links to repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "intents"]
 	path = intents
-	url = https://github.com/home-assistant/intents/
+	url = https://github.com/OHF-Voice/intents/
 	branch = main

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Home Assistant Intents Package
 
-Packaging for [intents](https://github.com/home-assistant/intents/)
+Packaging for [intents](https://github.com/OHF-Voice/intents/)
 
 
 ## Install
@@ -8,7 +8,7 @@ Packaging for [intents](https://github.com/home-assistant/intents/)
 Clone the repo and create a virtual environment:
 
 ``` sh
-git clone --recursive https://github.com/home-assistant/intents-package
+git clone --recursive https://github.com/OHF-Voice/intents-package
 cd intents-package
 script/setup
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">=3.9.0"
 
 [project.urls]
-"Source Code" = "https://github.com/home-assistant/intents"
+"Source Code" = "https://github.com/OHF-Voice/intents"
 
 [tool.setuptools]
 platforms = ["any"]


### PR DESCRIPTION
migrates all old links to `https://github.com/home-assistant/intents` to `https://github.com/OHF-Voice/intents`

similar to https://github.com/OHF-Voice/intents/pull/3408